### PR TITLE
fix/normalize-menus

### DIFF
--- a/ncloud/parseFood/modules/normalize.js
+++ b/ncloud/parseFood/modules/normalize.js
@@ -62,11 +62,11 @@ function normalizeHu(place = '후생관', menus) {
       // { place, week: '금', time: '중식', category: '오므라이스', menus: menus[41] },
     ],
     dinner: [
-      { place, week: '월', time: '석식', category: '백반', menus: '운영 없음' },
-      { place, week: '화', time: '석식', category: '백반', menus: '운영 없음' },
-      { place, week: '수', time: '석식', category: '백반', menus: '운영 없음' },
-      { place, week: '목', time: '석식', category: '백반', menus: '운영 없음' },
-      { place, week: '금', time: '석식', category: '백반', menus: '운영 없음' },
+      { place, week: '월', time: '석식', category: '백반', menus: '운영없음' },
+      { place, week: '화', time: '석식', category: '백반', menus: '운영없음' },
+      { place, week: '수', time: '석식', category: '백반', menus: '운영없음' },
+      { place, week: '목', time: '석식', category: '백반', menus: '운영없음' },
+      { place, week: '금', time: '석식', category: '백반', menus: '운영없음' },
     ]
   }
 }

--- a/ncloud/parseFood/modules/normalize.js
+++ b/ncloud/parseFood/modules/normalize.js
@@ -30,58 +30,43 @@ function normalizeHu(place = '후생관', menus) {
       { place, week: '월', time: '중식', category: '찌개', menus: menus[5] },
       { place, week: '월', time: '중식', category: '돌솥', menus: menus[10] },
       { place, week: '월', time: '중식', category: '특식', menus: menus[15] },
-      // { place, week: '월', time: '중식', category: '도시락', menus: menus[20] },
-      // { place, week: '월', time: '중식', category: '덮밥 비빔밥', menus: menus[25].split('/').join('\n') },
       { place, week: '월', time: '중식', category: '샐러드', menus: menus[30] },
-      // { place, week: '월', time: '중식', category: '돈까스', menus: menus[35] },
-      { place, week: '월', time: '중식', category: '오므라이스', menus: menus[36]+'\n'+menus[37] },
+      // { place, week: '월', time: '중식', category: '오므라이스', menus: menus[37] },
 
       // 화
       { place, week: '화', time: '중식', category: '찌개', menus: menus[6] },
       { place, week: '화', time: '중식', category: '돌솥', menus: menus[11] },
       { place, week: '화', time: '중식', category: '특식', menus: menus[16] },
-      // { place, week: '화', time: '중식', category: '도시락', menus: menus[21] },
-      // { place, week: '화', time: '중식', category: '덮밥 비빔밥', menus: menus[26].split('/').join('\n') },
       { place, week: '화', time: '중식', category: '샐러드', menus: menus[31] },
-      // { place, week: '월', time: '중식', category: '돈까스', menus: menus[35] },
-      { place, week: '화', time: '중식', category: '오므라이스', menus: menus[36]+'\n'+menus[38] },
+      // { place, week: '화', time: '중식', category: '오므라이스', menus: menus[38] },
 
       // 수
       { place, week: '수', time: '중식', category: '찌개', menus: menus[7] },
       { place, week: '수', time: '중식', category: '돌솥', menus: menus[12] },
       { place, week: '수', time: '중식', category: '특식', menus: menus[17] },
-      // { place, week: '수', time: '중식', category: '도시락', menus: menus[22] },
-      // { place, week: '수', time: '중식', category: '덮밥 비빔밥', menus: menus[27].split('/').join('\n') },
       { place, week: '수', time: '중식', category: '샐러드', menus: menus[32] },
-      // { place, week: '월', time: '중식', category: '돈까스', menus: menus[35] },
-      { place, week: '수', time: '중식', category: '오므라이스', menus: menus[36]+'\n'+menus[39] },
+      // { place, week: '수', time: '중식', category: '오므라이스', menus: menus[39] },
 
       // 목 
       { place, week: '목', time: '중식', category: '찌개', menus: menus[8] },
       { place, week: '목', time: '중식', category: '돌솥', menus: menus[13] },
       { place, week: '목', time: '중식', category: '특식', menus: menus[18] },
-      // { place, week: '목', time: '중식', category: '도시락', menus: menus[23] },
-      // { place, week: '목', time: '중식', category: '덮밥 비빔밥', menus: menus[28].split('/').join('\n') },
       { place, week: '목', time: '중식', category: '샐러드', menus: menus[33] },
-      // { place, week: '월', time: '중식', category: '돈까스', menus: menus[35] },
-      { place, week: '금', time: '중식', category: '오므라이스', menus: menus[36]+'\n'+menus[40] },
+      // { place, week: '목', time: '중식', category: '오므라이스', menus: menus[40] },
 
       // 금
       { place, week: '금', time: '중식', category: '찌개', menus: menus[9] },
       { place, week: '금', time: '중식', category: '돌솥', menus: menus[14] },
       { place, week: '금', time: '중식', category: '특식', menus: menus[19] },
-      // { place, week: '금', time: '중식', category: '도시락', menus: menus[24] },
-      // { place, week: '금', time: '중식', category: '덮밥 비빔밥', menus: menus[29].split('/').join('\n') },
       { place, week: '금', time: '중식', category: '샐러드', menus: menus[34] },
-      // { place, week: '월', time: '중식', category: '돈까스', menus: menus[35] },
-      { place, week: '금', time: '중식', category: '오므라이스', menus: menus[36]+'\n'+menus[41] },
+      // { place, week: '금', time: '중식', category: '오므라이스', menus: menus[41] },
     ],
     dinner: [
-      { place, week: '월', time: '석식', category: '백반', menus: menus[20] },
-      { place, week: '화', time: '석식', category: '백반', menus: menus[21] },
-      { place, week: '수', time: '석식', category: '백반', menus: menus[22] },
-      { place, week: '목', time: '석식', category: '백반', menus: menus[23] },
-      { place, week: '금', time: '석식', category: '백반', menus: menus[24] },
+      { place, week: '월', time: '석식', category: '백반', menus: '운영 없음' },
+      { place, week: '화', time: '석식', category: '백반', menus: '운영 없음' },
+      { place, week: '수', time: '석식', category: '백반', menus: '운영 없음' },
+      { place, week: '목', time: '석식', category: '백반', menus: '운영 없음' },
+      { place, week: '금', time: '석식', category: '백반', menus: '운영 없음' },
     ]
   }
 }


### PR DESCRIPTION
# 오류 사항

1. 현재 후생관 메뉴에서 석식을 제대로 표기하지 못합니다.
2. 후생관 석식을 중식 중의 일부메뉴로 응답합니다.
3. “이번주 후생관”으로 요청하여 석식리스트를 전부 확인하면 해당 요일의 석식이 금요일의 중식 찌개, 돌솥, 특식, 샐러드, 오므라이스 순으로 응답되는 규칙을 찾을 수 있습니다. (실행결과 섹션의 gist참조)
<img src="https://github.com/hmu332233/LetMeKnow.jbnu--lambda/assets/33001997/dd716f5e-268c-4d05-acaa-dbc3472dae83" width="45%" />


# 오류 근거

1. core repo의 modules/message/M_Menu.rb에서 makeHuMenusMessage함수가 저장된 학식 메뉴를 이용해 메시지를 생성함을 확인할 수 있습니다. (https://github.com/hmu332233/LetMeKnow.jbnu--core/blob/develop/app/modules/ManagementApi.rb#L78)
2. 정규화하여 저장한 JSON에서 키값을 이용하는 방식이 아니라, 배열에서 인덱스를 직접 참조하고 있음을 확인할 수 있습니다.
3. 82번줄에서 dinnerIndex=25+day로 작성되어있는데, 현재 파서구조를 변경하면서 각 요일당 파싱하는 메뉴가 5개로 증가하면서 정확히 5개씩 메뉴가 뒤로 밀리고 그자리에 금요일 중식메뉴들이 들어가 있기때문에 해당 현상이 발생했다고 추측할 수 있습니다.
5. 아래의 사진에서 확인할 수 있듯 dinnerIndex가 25부터 시작하므로 석식의 메뉴가 금요일 중식으로 보고되는 현상과 일치함을 알 수 있습니다.
![dd](https://github.com/hmu332233/LetMeKnow.jbnu--lambda/assets/33001997/c2becb67-d7b8-4f08-8c7c-64a9761cac8e)

# 임시 해결방안

1. ruby언어에 대해 정확히 알지 못하기 때문에 어디까지나 추측이고, core 프로젝트에 개입하기에는 어려움이 많을 것 같습니다.
2. 후생관 파싱 메뉴에서 하나를 임의로 제거하면 menus 배열의 크기가 30로 줄어들기때문에 석식이 없음을 정확하게 표현할 수 있지 않을까 생각합니다. (menus 배열의 크기를 기존과 동일하게 되돌려 놓기 위함)

# 작업내용

1. normalize모듈에서 후생관 오므라이스 메뉴 제거**😢**
2. 주석 제거 및 요일이 잘못 기재된 코드 수정
3. 후생관 석식메뉴 운영 없음으로 수정

# 실행결과
2024-01-05 후생관 파싱 결과: https://gist.github.com/jinseok1006/1e26ca4df7a0dac7a874c9086209d559

https://github.com/hmu332233/LetMeKnow.jbnu--lambda/assets/33001997/b6d5d88b-5109-461e-8150-893cd826240d

의도대로 menus 배열의 크기가 30이 되었습니다.
core에서 석식 메뉴 없음이 정상적으로 표현되기를 기대합니다.